### PR TITLE
ExtensionRepository refactoring

### DIFF
--- a/src/Repositories/ExtensionCacheRepository.php
+++ b/src/Repositories/ExtensionCacheRepository.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Flagrow\Bazaar\Repositories;
+
+use Flagrow\Bazaar\Extensions\ExtensionUtils;
+use Flagrow\Bazaar\Search\FlagrowApi;
+use Flagrow\Bazaar\Traits\Cachable;
+use Illuminate\Contracts\Cache\Store;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Psr\Http\Message\ResponseInterface;
+
+class ExtensionCacheRepository
+{
+    use Cachable;
+
+    /**
+     * @var Store
+     */
+    protected $store;
+
+    /**
+     * @var FlagrowApi
+     */
+    protected $api;
+
+    const CACHE_KEY = 'flagrow.io.packages';
+    const CACHE_EXPIRE = 60; // minutes
+
+    public function __construct(Store $store, FlagrowApi $api)
+    {
+        $this->store = $store;
+        $this->api = $api;
+    }
+
+    /**
+     * Extracts the data from an API response
+     * @param ResponseInterface $response
+     * @return array
+     */
+    protected function unpackResponseData(ResponseInterface $response)
+    {
+        $json = json_decode($response->getBody()->getContents(), true);
+
+        return Arr::get($json, 'data', []);
+    }
+
+    /**
+     * (re)freshes extension data from the api
+     * @return array
+     */
+    protected function allExtensionsFromApi()
+    {
+        $query = [
+            'page[size]' => 9999,
+            'page[number]' => 1, // Offset is zero-based, page number is 1-based
+            'sort' => 'title' // Sort by package name per default
+        ];
+
+        return $this->getOrSetCache(self::CACHE_KEY, function () use ($query) {
+            $response = $this->api->get('packages', compact('query'));
+
+            return Collection::make($this->unpackResponseData($response))->keyBy(function($extension) {
+                return ExtensionUtils::packageToId(Arr::get($extension, 'attributes.name'));
+            })->toArray();
+        });
+    }
+
+    /**
+     * Updates the cache with the data from an API response
+     * @param ResponseInterface $response
+     */
+    public function updateCacheFromResponse(ResponseInterface $response)
+    {
+        $extensions = $this->store->get(self::CACHE_KEY);
+
+        $data = $this->unpackResponseData($response);
+
+        // If the cache expired, there's no reason to update it. It will be refilled completely next time it's used
+        // If the response contains no data we also exit
+        if (!$extensions || empty($data)) {
+            return;
+        }
+
+        $extensions_updated = Collection::make($extensions)->map(function ($extension) use ($data) {
+            if (Arr::get($extension, 'id') === Arr::get($data, 'id')) {
+                return $data;
+            }
+
+            return $extension;
+        })->toArray();
+
+        $this->store->put(self::CACHE_KEY, $extensions_updated, self::CACHE_EXPIRE);
+    }
+
+    /**
+     * All extensions available
+     * @return Collection
+     */
+    public function index()
+    {
+        return Collection::make($this->allExtensionsFromApi());
+    }
+
+    /**
+     * A specific extension
+     * @param string $extensionId Extension id (with $)
+     * @return array
+     */
+    public function get($extensionId)
+    {
+        $extensions = $this->allExtensionsFromApi();
+
+        return Arr::get($extensions, $extensionId);
+    }
+}

--- a/src/Repositories/ExtensionFactory.php
+++ b/src/Repositories/ExtensionFactory.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Flagrow\Bazaar\Repositories;
+
+use Flagrow\Bazaar\Extensions\Extension;
+use Flarum\Extension\ExtensionManager;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+
+class ExtensionFactory
+{
+    /**
+     * @var ExtensionCacheRepository
+     */
+    protected $flagrowCache;
+
+    /**
+     * @var ExtensionManager
+     */
+    protected $manager;
+
+    public function __construct(ExtensionCacheRepository $flagrowCache, ExtensionManager $manager)
+    {
+        $this->flagrowCache = $flagrowCache;
+        $this->manager = $manager;
+    }
+
+    /**
+     * Internal method to create the extension with various sources for the Flagrow cache
+     * @param array $flagrowExtension
+     * @return Extension
+     */
+    protected function createFromApiData($flagrowExtension)
+    {
+        $extension = Extension::createFromAttributes(Arr::get($flagrowExtension, 'attributes'));
+
+        $installedExtension = $this->manager->getExtension($extension->getShortName());
+
+        if ($installedExtension) {
+            $extension->setInstalledExtension($installedExtension);
+        }
+
+        return $extension;
+    }
+
+    /**
+     * Builds an extension object from the Flagrow cache and the Flarum manager if available
+     * @param string $extensionId Extension id (with $)
+     * @return Extension
+     */
+    public function create($extensionId)
+    {
+        $flagrowExtension = $this->flagrowCache->get($extensionId);
+
+        if (!$flagrowExtension) {
+            return null;
+        }
+
+        return $this->createFromApiData($flagrowExtension);
+    }
+
+    /**
+     * Builds the full list of extensions from the Flagrow cache
+     * @return Collection
+     */
+    public function createAll()
+    {
+        return $this->flagrowCache->index()->map(function($flagrowExtension) {
+            return $this->createFromApiData($flagrowExtension);
+        });
+    }
+}

--- a/src/Repositories/ExtensionRepository.php
+++ b/src/Repositories/ExtensionRepository.php
@@ -8,34 +8,21 @@ use Flagrow\Bazaar\Extensions\Extension;
 use Flagrow\Bazaar\Extensions\ExtensionUtils;
 use Flagrow\Bazaar\Extensions\PackageManager;
 use Flagrow\Bazaar\Jobs\CacheClearJob;
-use Flagrow\Bazaar\Search\FlagrowApi as Api;
-use Flagrow\Bazaar\Traits\Cachable;
+use Flagrow\Bazaar\Search\FlagrowApi;
 use Flarum\Core\Search\SearchResults;
 use Flarum\Event\ExtensionWasUninstalled;
 use Flarum\Extension\ExtensionManager;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 
 class ExtensionRepository
 {
-    use Cachable;
     /**
-     * @var Extension
+     * @var FlagrowApi
      */
-    protected $extension;
-    /**
-     * @var ExtensionManager
-     */
-    protected $manager;
-    /**
-     * @var Api
-     */
-    private $client;
-    /**
-     * @var PackageManager
-     */
-    protected $packages;
+    private $flagrowApi;
     /**
      * @var Dispatcher
      */
@@ -43,53 +30,41 @@ class ExtensionRepository
     /**
      * @var CacheClearJob
      */
-    private $flush;
-
+    protected $cacheClearJob;
     /**
-     * ExtensionRepository constructor.
-     * @param ExtensionManager $manager
-     * @param PackageManager $packages
-     * @param Api $client
-     * @param Dispatcher $events
-     * @param CacheClearJob $flush
+     * @var PackageManager
      */
+    protected $packageManager;
+    /**
+     * @var ExtensionManager
+     */
+    protected $extensionManager;
+    /**
+     * @var ExtensionCacheRepository
+     */
+    protected $extensionCache;
+    /**
+     * @var ExtensionFactory
+     */
+    protected $extensionFactory;
+
     function __construct(
-        ExtensionManager $manager,
-        PackageManager $packages,
-        Api $client,
+        FlagrowApi $client,
         Dispatcher $events,
-        CacheClearJob $flush
+        CacheClearJob $cacheClearJob,
+        PackageManager $packageManager,
+        ExtensionManager $extensionManager,
+        ExtensionCacheRepository $extensionCache,
+        ExtensionFactory $extensionFactory
     )
     {
-        $this->manager = $manager;
-        $this->client = $client;
-        $this->packages = $packages;
+        $this->flagrowApi = $client;
         $this->events = $events;
-        $this->flush = $flush;
-    }
-
-    /**
-     * @return Collection all extensions from the remote client
-     */
-    public function allExtensionsFromClient()
-    {
-        $query = [
-            'page[size]' => 9999,
-            'page[number]' => 1, // Offset is zero-based, page number is 1-based
-            'sort' => 'title' // Sort by package name per default
-        ];
-
-        $data = $this->getOrSetCache('flagrow.io.search.list', function () use ($query) {
-            $response = $this->client->get('packages', compact('query'));
-
-            $json = json_decode((string)$response->getBody(), true);
-
-            return Arr::get($json, 'data', []);
-        });
-
-        return Collection::make($data)->map(function ($package) {
-            return $this->createExtension($package);
-        })->keyBy('id');
+        $this->cacheClearJob = $cacheClearJob;
+        $this->packageManager = $packageManager;
+        $this->extensionManager = $extensionManager;
+        $this->extensionCache = $extensionCache;
+        $this->extensionFactory = $extensionFactory;
     }
 
     /**
@@ -105,6 +80,8 @@ class ExtensionRepository
         }
 
         return $extensions->filter(function ($extension) use ($search) {
+            /** @var Extension $extension */
+
             // Look for the serch term in all these things
             $searchIn = [
                 $extension->getPackage(),
@@ -129,7 +106,7 @@ class ExtensionRepository
      */
     public function index(array $params = [])
     {
-        $extensions = $this->allExtensionsFromClient();
+        $extensions = $this->extensionFactory->createAll();
 
         foreach (Arr::get($params, 'filter', []) as $filter => $value) {
             switch ($filter) {
@@ -141,7 +118,7 @@ class ExtensionRepository
             }
         }
 
-        return new SearchResults($extensions, true);
+        return new SearchResults(EloquentCollection::make($extensions), true);
     }
 
     /**
@@ -154,41 +131,7 @@ class ExtensionRepository
             $id = ExtensionUtils::packageToId($id);
         }
 
-        $response = $this->client->get("packages/$id");
-
-        if ($response->getStatusCode() == 200) {
-            $json = json_decode($response->getBody()->getContents(), true);
-            return $this->createExtension(Arr::get($json, 'data', []));
-        }
-
-        return null;
-    }
-
-    /**
-     * Create an Extension object and map all data sources.
-     *
-     * @param array $apiPackage
-     * @return Extension
-     */
-    public function createExtension(array $apiPackage)
-    {
-        $extension = Extension::createFromAttributes($apiPackage['attributes']);
-
-        $this->refreshInstalledExtension($extension);
-
-        return $extension;
-    }
-
-    /**
-     * @param Extension $extension
-     */
-    protected function refreshInstalledExtension(Extension &$extension)
-    {
-        $installedExtension = $this->manager->getExtension($extension->getShortName());
-
-        if (!is_null($installedExtension)) {
-            $extension->setInstalledExtension($installedExtension);
-        }
+        return $this->extensionFactory->create($id);
     }
 
     /**
@@ -199,11 +142,11 @@ class ExtensionRepository
      */
     public function installExtension($package)
     {
-        $this->packages->requirePackage($package);
+        $this->packageManager->requirePackage($package);
 
         $extension = $this->getExtension($package);
 
-        $this->flush->fire();
+        $this->cacheClearJob->fire();
 
         $this->events->fire(
             new ExtensionWasInstalled($extension->getInstalledExtension())
@@ -221,19 +164,17 @@ class ExtensionRepository
     {
         $extension = $this->getExtension($package);
 
-        $this->packages->updatePackage($extension->getPackage());
+        $this->packageManager->updatePackage($extension->getPackage());
 
-        $this->manager->migrate($extension->getInstalledExtension());
+        $this->extensionManager->migrate($extension->getInstalledExtension());
 
-        $this->flush->fire();
+        $this->cacheClearJob->fire();
 
         $this->events->fire(
             new ExtensionWasUpdated($extension->getInstalledExtension())
         );
 
-        $this->refreshInstalledExtension($extension);
-
-        return $extension;
+        return $this->getExtension($package);
     }
 
     /**
@@ -245,18 +186,19 @@ class ExtensionRepository
         $extension = $this->getExtension($package);
 
         if ($extension->isEnabled()) {
-            $this->manager->disable($extension->id);
+            $this->extensionManager->disable($extension->id);
         }
 
-        $this->manager->migrateDown($extension->getInstalledExtension());
+        $this->extensionManager->migrateDown($extension->getInstalledExtension());
 
-        $this->packages->removePackage($extension->getPackage());
+        $this->packageManager->removePackage($extension->getPackage());
 
         $installedExtension = $extension->getInstalledExtension();
 
+        // This can't be updated automaticall by calling getExtension() again before we haven't reloaded the extension manager
         $extension->setInstalledExtension(null);
 
-        $this->flush->fire();
+        $this->cacheClearJob->fire();
 
         $this->events->fire(
             new ExtensionWasUninstalled($installedExtension)
@@ -272,7 +214,7 @@ class ExtensionRepository
      */
     public function favorite($package, $favorite = true)
     {
-        $response = $this->client->post('packages/favorite', [
+        $response = $this->flagrowApi->post('packages/favorite', [
             'form_params' => [
                 'package_id' => $package,
                 'favorite' => $favorite,
@@ -280,8 +222,9 @@ class ExtensionRepository
         ]);
 
         if (in_array($response->getStatusCode(), [200, 201])) {
-            $json = json_decode($response->getBody()->getContents(), true);
-            return $this->createExtension(Arr::get($json, 'data', []));
+            $this->extensionCache->updateCacheFromResponse($response);
+
+            return $this->extensionFactory->create($package);
         }
 
         if ($response->getStatusCode() === 409) {


### PR DESCRIPTION
Refactored the ExtensionRepository into 3 classes:

- The actual repository, which holds extension logic used in Bazaar
- The cache repository, responsible of saving and updating the data from flagrow.io
- The extension factory, which does the assembly of the flagrow.io data and the extension manager data

Also renamed a bunch of variables in ExtensionRepository, their naming was very confusing.

There are probably still improvements to do. But I think it's already a lot cleaner.

It's now possible to update only part of the cache. It's used for the favorite feature and I plan to use it for premium extension state as well in #66 